### PR TITLE
Removed duplicated header

### DIFF
--- a/docs/demo-mode-money.md
+++ b/docs/demo-mode-money.md
@@ -1,3 +1,2 @@
-## Demo Mode - How do I get money?
 If you need money while beeing in the sandbox mode you can simply hit the money ($) button on the Dashboard page this will add 500 Euro to the selected account.
  ![Add money to demo account](images/demo-mode-money/1.png)

--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -1,4 +1,3 @@
-## Demo Mode
 You can setup bunqDesktop to use a Sandbox account this way you can test the app and see if you like it without having to use your real account.
 
 In order to do so you first have to startup a password when you first start bunqDesktop:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,1 @@
-## Home page
-
 Welcome to the bunqDesktop Wiki here you can find usefull information and tricks for bunqDesktop

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,3 @@
-## Installation
 #### One click installers
 Download the latest version of bunqDesktop from the [GitHub releases page.](https://github.com/bunqCommunity/bunqDesktop/releases)
 


### PR DESCRIPTION
Mkdocs adds its own header, this makes the header in the docs files useless.
<img width="338" alt="bildschirmfoto 2018-08-28 um 17 51 10" src="https://user-images.githubusercontent.com/6145026/44734851-26376080-aaeb-11e8-840d-4fdb8d4fd59d.png">
