### PR TITLE
Rename brew cask from bunq to bunqdesktop

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ You can directly search for 'bunqDesktop' in the Ubuntu store or use  the snap c
 `sudo snap install bunqdesktop`
 
 #### [Brew Cask](https://caskroom.github.io/)
-`brew cask install bunq`
+`brew cask install bunqdesktop`
 
 #### [Chocolatey](https://chocolatey.org/packages/bunqdesktop)
 `choco install bunqdesktop`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ You can directly search for 'bunqDesktop' in the Ubuntu store or use  the snap c
 `sudo snap install bunqdesktop`
 
 #### [Brew Cask](https://caskroom.github.io/)
-`brew cask install bunqdesktop`
+`brew cask install bunqcommunity-bunq`
 
 #### [Chocolatey](https://chocolatey.org/packages/bunqdesktop)
 `choco install bunqdesktop`


### PR DESCRIPTION
Depends on Homebrew/homebrew-cask#52373 to be merged